### PR TITLE
[update] dependency package

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
 # lint
 flake8==4.0.1
-black==21.11b1
+black==22.3.0
 flake8-docstrings==1.6.0
 flake8-quotes==3.3.1
-flake8-bugbear==21.11.29
+flake8-bugbear==22.3.23
 
 # test
-pytest==6.2.5
+pytest==7.1.1
 pytest-cov==3.0.0
 
 # notebook
-ipykernel==6.6.0
+ipykernel==6.13.0


### PR DESCRIPTION
## 問題
blackのバージョンが低いことで、CIが正しく動作していない。

例: https://github.com/yamap55/tdd_word_filter/actions/runs/2199141205

## 対応内容
- blackのバージョンを最新に更新
  - https://pypi.org/project/black/
- ついでに、依存ライブラリのバージョンを最新に更新
  - 本ブランチをcheckout後に↓で確認可能
    -  `pip install -r requirements-dev.txt` -> `pip list -o`
  - コンテナのrebuildでも確認可能